### PR TITLE
reupdate to v1.9.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spdlog" %}
-{% set version = "1.8.5" %}
-{% set sha256 = "944d0bd7c763ac721398dca2bb0f3b5ed16f67cef36810ede5061f35a543b4b8" %}
+{% set version = "1.9.2" %}
+{% set sha256 = "6fff9215f5cb81760be4cc16d033526d1080427d236e86d70bb02994f85e3d38" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
- rebuild 1.8.5
- MNT: Re-rendered with conda-build 3.21.7, conda-smithy 3.16.2, and conda-forge-pinning 2022.01.29.15.10.18
- take back to 1.9.2

thanks @rongou for merging 1.8.5. Here's again taking it back to 1.9.2 though it is not really needed. Thanks team!!!
