### PR TITLE
migrate for fmt 12.0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -13,8 +13,8 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fmt:
-- '11.2'
+- '12.0'
 spdlog:
-- '1.15'
+- '1.16'
 target_platform:
 - linux-64

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -13,8 +13,8 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fmt:
-- '11.2'
+- '12.0'
 spdlog:
-- '1.15'
+- '1.16'
 target_platform:
 - linux-aarch64

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -13,8 +13,8 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fmt:
-- '11.2'
+- '12.0'
 spdlog:
-- '1.15'
+- '1.16'
 target_platform:
 - linux-ppc64le

--- a/.ci_support/migrations/fmt12_spdlog116.yaml
+++ b/.ci_support/migrations/fmt12_spdlog116.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for fmt 12.0 and spdlog 1.16
+  kind: version
+  migration_number: 1
+migrator_ts: 1760196591.995821
+fmt:
+- '12.0'
+spdlog:
+- '1.16'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -15,10 +15,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 fmt:
-- '11.2'
+- '12.0'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 spdlog:
-- '1.15'
+- '1.16'
 target_platform:
 - osx-64

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -15,10 +15,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 fmt:
-- '11.2'
+- '12.0'
 macos_machine:
 - arm64-apple-darwin20.0.0
 spdlog:
-- '1.15'
+- '1.16'
 target_platform:
 - osx-arm64

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -7,8 +7,8 @@ channel_targets:
 cxx_compiler:
 - vs2022
 fmt:
-- '11.2'
+- '12.0'
 spdlog:
-- '1.15'
+- '1.16'
 target_platform:
 - win-64

--- a/.ci_support/win_arm64_.yaml
+++ b/.ci_support/win_arm64_.yaml
@@ -7,8 +7,8 @@ channel_targets:
 cxx_compiler:
 - vs2022
 fmt:
-- '11.2'
+- '12.0'
 spdlog:
-- '1.15'
+- '1.16'
 target_platform:
 - win-arm64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/fix.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('spdlog', max_pin='x.x') }}
 


### PR DESCRIPTION
This was discussed in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7837, but I forgot to build a compatible spdlog. Since @bluescarni and @jjerphan already agreed on the strategy in that PR, I'm going to merge this in an expedited fashion, because otherwise the [migrator](https://conda-forge.org/status/migration/?name=fmt12_spdlog116) will keep failing to resolve and eventually give up.